### PR TITLE
Fixes duplicate keys warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -427,7 +427,7 @@ export default class Banner extends Component {
         this.elementCount = length;
         let newChildren = [];
         if (autoLoop && length > 0) {
-            newChildren.push(children[length - 1], ...children, children[0]);
+            newChildren.push(React.cloneElement(children[length - 1], {key: length + 1}), ...children, React.cloneElement(children[0], {key: length + 2}));
         }else {
             newChildren.push(...children);
         }


### PR DESCRIPTION
Whenever there are children inside Banner component which are generated by map function with keys, this PR will make sure that the warning for duplicate keys won't show up